### PR TITLE
delay-job-completion: Add the ability to modify delay duration

### DIFF
--- a/action-delay-job-completion/action.yaml
+++ b/action-delay-job-completion/action.yaml
@@ -13,5 +13,9 @@ runs:
       shell: bash
       run: |
         echo "Sleeping for ${{ inputs.completion_delay_m }} minutes.
-        Create a file named 'cancel_delay' under $GITHUB_WORKSPACE or under / to cancel."
-        timeout ${{ inputs.completion_delay_m }}m bash -c "while [ ! -f /cancel_delay -a ! -f $GITHUB_WORKSPACE/cancel_delay ]; do sleep 5; done" || true
+        Delete the file '$GITHUB_WORKSPACE/timeout_date' to cancel.
+        You can update that file with:
+          date '+%s' --date='now + <X> minutes' > $GITHUB_WORKSPACE/timeout_date to change the delay."
+
+        date '+%s' --date='now + ${{ inputs.completion_delay_m }} minutes' > $GITHUB_WORKSPACE/timeout_date
+        while [ $(date '+%s') -lt $(cat $GITHUB_WORKSPACE/timeout_date 2>/dev/null || echo 0) ]; do sleep 5; done


### PR DESCRIPTION
A suggestion from @oliviergaraud: Allow the user to modify the delay while connected in the runner. 