### PR TITLE
Feature/fix final status action

### DIFF
--- a/.github/workflows/docker-upload.yaml
+++ b/.github/workflows/docker-upload.yaml
@@ -15,6 +15,8 @@ jobs:
           access_token: ${{ secrets.GITHUB_TOKEN }}
       - run: docker pull "ghcr.io/${{ github.repository }}/test:${{ github.sha }}"
       - uses: ./upload_final_status
+        env:
+          GH_TOKEN: ${{ github.token }}
         if: always()
         with:
           ARTIFACTS_USER: ${{ secrets.ARTIFACTS_USER }}

--- a/.github/workflows/final_status_failed.yaml
+++ b/.github/workflows/final_status_failed.yaml
@@ -1,0 +1,27 @@
+name: 'Test failed final status'
+
+on:
+  push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    # we needs this in order to successfully pass the test
+    continue-on-error: true
+    steps:
+      - name: simulate a failure in a job
+        run: exit 1
+
+  final-status:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./upload_final_status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        if: always()
+        with:
+          ARTIFACTS_USER: ${{ secrets.ARTIFACTS_USER }}
+          ARTIFACTS_PASSWORD: ${{ secrets.ARTIFACTS_PASSWORD }}

--- a/upload_final_status/README.md
+++ b/upload_final_status/README.md
@@ -19,6 +19,32 @@ The action requires the artifact `usrename` and `password` in order to upload th
 | ARTIFACTS_USER     | The artifacts username | ✅        |
 | ARTIFACTS_PASSWORD | The artifacts password | ✅        |
 
+### Env
+
+It is mandatory to set the following env variable with the github token
+to use with the github cli tool `gh`.
+
+- `GH_TOKEN`: usually it is set to `${{ github.token }}`
+
+  but can be any token like: `${{ secrets.GIT_ACCESS_TOKEN }}`
+
+as follow:
+
+```yaml
+jobs:
+  final-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: upload final status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        uses: scality/actions/upload_final_status@main
+        with:
+          ARTIFACTS_USER: ${{ secrets.ARTIFACTS_USER }}
+          ARTIFACTS_PASSWORD: ${{ secrets.ARTIFACTS_PASSWORD }}
+```
+
 **Note:** it is important to set the `always()` condition on the step
 that calls this action so it's always called at the end.
 
@@ -53,6 +79,8 @@ jobs:
     steps:
       - name: upload final status
         if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
         uses: scality/actions/upload_final_status@main
         with:
           ARTIFACTS_USER: ${{ secrets.ARTIFACTS_USER }}

--- a/upload_final_status/README.md
+++ b/upload_final_status/README.md
@@ -26,7 +26,7 @@ to use with the github cli tool `gh`.
 
 - `GH_TOKEN`: usually it is set to `${{ github.token }}`
 
-  but can be any token like: `${{ secrets.GIT_ACCESS_TOKEN }}`
+  but can be any GitHub token, like: `${{ secrets.MY_GITHUB_TOKEN }}`
 
 as follow:
 

--- a/upload_final_status/action.yaml
+++ b/upload_final_status/action.yaml
@@ -12,6 +12,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: check required binaries
+      shell: bash
+      run: |
+        gh --version
+        wc --version
+        mktemp --version
     - name: create artifacts folder
       id: temp-dir
       shell: bash
@@ -19,14 +25,24 @@ runs:
         TEMP=$(mktemp -d)
         echo "Temp directory: ${TEMP}"
         echo "TEMP=$TEMP" >> $GITHUB_OUTPUT
+    - name: get workflow status
+      shell: bash
+      id: nr-failed-jobs
+      run: |
+        nr_failed=$(gh -R ${{ github.repository }} \
+          run view \
+          --json="jobs" --jq='.jobs[] | select(.status == "completed" and .conclusion == "failure").conclusion' \
+          ${{ github.run_id }} | wc -l)
+        echo "failed jobs: ${nr_failed}"
+        echo "NR_FAILED=${nr_failed}" >> ${GITHUB_OUTPUT}
     - name: write failed result
       shell: bash
-      if: failure()
+      if: steps.nr-failed-jobs.outputs.NR_FAILED > 0
       run: |
         echo -n "FAILED" > ${{ steps.temp-dir.outputs.TEMP }}/.final_status
     - name: write successful result
       shell: bash
-      if: success()
+      if: steps.nr-failed-jobs.outputs.NR_FAILED == 0
       run: |
         echo -n "SUCCESSFUL" > ${{ steps.temp-dir.outputs.TEMP }}/.final_status
     - name: upload file to artifacts


### PR DESCRIPTION
the use of `failure` or `success` only works for the steps in the current jobs.
The only way to identify if any previous job has failed is through the API and going through the result of all completed jobs.

Use `gh` tool for that. 

It is installed on all runners.

**note:** `gh` tool is not installed when running a docker image, we must check that it's running before trying anything.

Added a new workflow to test that we can successfully upload the final status in case a previous job failed. It must have the `continue-on-error` property set to `true` in order to merge any PR.