### PR TITLE
HD-2909 fix the success/failure condition

### DIFF
--- a/upload_final_status/README.md
+++ b/upload_final_status/README.md
@@ -14,10 +14,11 @@ The action requires the artifact `usrename` and `password` in order to upload th
 
 ### Inputs
 
-| Name               | Description            | Required |
-|--------------------|------------------------|----------|
-| ARTIFACTS_USER     | The artifacts username | ✅        |
-| ARTIFACTS_PASSWORD | The artifacts password | ✅        |
+| Name               | Description                   | Required |
+|--------------------|-------------------------------|----------|
+| ARTIFACTS_USER     | The artifacts username        | ✅       |
+| ARTIFACTS_PASSWORD | The artifacts password        | ✅       |
+| JOBS_RESULTS       | Concatenation of jobs results | ✅       |
 
 **Note:** it is important to set the `always()` condition on the step
 that calls this action so it's always called at the end.
@@ -57,5 +58,6 @@ jobs:
         with:
           ARTIFACTS_USER: ${{ secrets.ARTIFACTS_USER }}
           ARTIFACTS_PASSWORD: ${{ secrets.ARTIFACTS_PASSWORD }}
+          JOBS_RESULTS: ${{ join(needs.*.result) }}
 
 ```

--- a/upload_final_status/action.yaml
+++ b/upload_final_status/action.yaml
@@ -8,6 +8,9 @@ inputs:
   ARTIFACTS_PASSWORD:
     description: The artifact password to upload the status
     required: true
+  JOBS_RESULTS:
+    descript: Concatenation of jobs results
+    required: true
 
 runs:
   using: composite
@@ -21,12 +24,12 @@ runs:
         echo "TEMP=$TEMP" >> $GITHUB_OUTPUT
     - name: write failed result
       shell: bash
-      if: failure()
+      if: ${{ contains(inputs.JOBS_RESULTS, 'failed') || contains(inputs.JOBS_RESULTS, 'cancelled') || contains(inputs.JOBS_RESULTS, 'skipped') }}
       run: |
         echo -n "FAILED" > ${{ steps.temp-dir.outputs.TEMP }}/.final_status
     - name: write successful result
       shell: bash
-      if: success()
+      if: ${{ !contains(inputs.JOBS_RESULTS, 'failed') && !contains(inputs.JOBS_RESULTS, 'cancelled') && !contains(inputs.JOBS_RESULTS, 'skipped') }}
       run: |
         echo -n "SUCCESSFUL" > ${{ steps.temp-dir.outputs.TEMP }}/.final_status
     - name: upload file to artifacts


### PR DESCRIPTION
The actions was always sending a successful .final_status object for every build whatever happens. I suspect that using success() or failure() inside this action is limited in scope and could not reflect the status of the CI run that called the action. From the caller point of view, success() or failure() are only usable in a "if:" step statement. So I had to do a trick to pass a concatenation of the needed jobs results. This is working as expected now.