### PR TITLE
Expose scality/action-artifacts outputs to the caller

### DIFF
--- a/.github/workflows/docker-upload.yaml
+++ b/.github/workflows/docker-upload.yaml
@@ -16,6 +16,21 @@ jobs:
       - run: docker pull "ghcr.io/${{ github.repository }}/test:${{ github.sha }}"
       - uses: ./upload_final_status
         if: always()
+        id: artifacts
         with:
           ARTIFACTS_USER: ${{ secrets.ARTIFACTS_USER }}
           ARTIFACTS_PASSWORD: ${{ secrets.ARTIFACTS_PASSWORD }}
+      - name: print outputs
+        run: |
+          echo "Link: ${{ steps.artifacts.outputs.link }}"
+          echo "Name: ${{ steps.artifacts.outputs.name }}"
+      - name: ensure outputs contains link and name
+        shell: python
+        run: |
+          link_prefix = "https://artifacts.scality.net/builds/github:scality:actions:staging-"
+          if "${{ steps.artifacts.outputs.link }}".find(link_prefix) < 0:
+            raise RuntimeError("the ouput link does not contain the expected prefix")
+
+          name_prefix = "github:scality:actions:staging-"
+          if "${{ steps.artifacts.outputs.name }}".find(name_prefix) < 0:
+            raise RuntimeError("the output name doe snot contain the expected name")

--- a/upload_final_status/action.yaml
+++ b/upload_final_status/action.yaml
@@ -12,6 +12,18 @@ inputs:
     description: Concatenation of jobs results
     required: true
 
+outputs:
+  name:
+    description: |
+      The name of the artifacts for a specific workflow.
+      This name will be unique for the whole workflow and can be
+      used by further steps to locate the artifacts inside a job.
+    value: ${{ steps.artifacts.outputs.name }}
+  link:
+    description: |
+      The full url in which artifacts will be stored.
+    value: ${{ steps.artifacts.outputs.link }}
+
 runs:
   using: composite
   steps:
@@ -34,6 +46,7 @@ runs:
         echo -n "SUCCESSFUL" > ${{ steps.temp-dir.outputs.TEMP }}/.final_status
     - name: upload file to artifacts
       uses: scality/action-artifacts@v3
+      id: artifacts
       with:
         method: upload
         url: https://artifacts.scality.net


### PR DESCRIPTION
Expose the output from the action scality/action-artifacts to the caller of the action scality/actions/upload_final_status.

Add a basic test too.