### PR TITLE
Delay-job-completion action: Stop delaying when tmate is not running 

### DIFF
--- a/action-delay-job-completion/action.yaml
+++ b/action-delay-job-completion/action.yaml
@@ -16,7 +16,7 @@ runs:
         --------------------------------------------------
         Sleeping for ${{ inputs.completion_delay_m }} minutes.
         To cancel, delete the file '$GITHUB_WORKSPACE/timeout_date' or end the debugging session.
-        To change the delay duraction, update the file '$GITHUB_WORKSPACE/timeout_date' with:
+        To change the delay duration, update the file '$GITHUB_WORKSPACE/timeout_date' with:
           date '+%s' --date='now + <X> minutes' > $GITHUB_WORKSPACE/timeout_date ."
         --------------------------------------------------
         EOF

--- a/action-delay-job-completion/action.yaml
+++ b/action-delay-job-completion/action.yaml
@@ -12,10 +12,22 @@ runs:
     - name: "Debug: Delay job completion"
       shell: bash
       run: |
-        echo "Sleeping for ${{ inputs.completion_delay_m }} minutes.
+        MESSAGE=$(cat << EOF
+        --------------------------------------------------
+        Sleeping for ${{ inputs.completion_delay_m }} minutes.
+        To cancel, delete the file '$GITHUB_WORKSPACE/timeout_date' or end the debugging session.
+        To change the delay duraction, update the file '$GITHUB_WORKSPACE/timeout_date' with:
+          date '+%s' --date='now + <X> minutes' > $GITHUB_WORKSPACE/timeout_date ."
+        --------------------------------------------------
+        EOF
+        )
+        echo "::notice title=Delay workflow completion::${MESSAGE}"
         Delete the file '$GITHUB_WORKSPACE/timeout_date' to cancel.
         You can update that file with:
           date '+%s' --date='now + <X> minutes' > $GITHUB_WORKSPACE/timeout_date to change the delay."
 
         date '+%s' --date='now + ${{ inputs.completion_delay_m }} minutes' > $GITHUB_WORKSPACE/timeout_date
-        while [ $(date '+%s') -lt $(cat $GITHUB_WORKSPACE/timeout_date 2>/dev/null || echo 0) ]; do sleep 5; done
+        while [ $(date '+%s') -lt $(cat $GITHUB_WORKSPACE/timeout_date 2>/dev/null || echo 0) ] && [[ -f /tmp/tmate.pid ]] && ps --pid $(cat /tmp/tmate.pid) &>/dev/null ;
+        do
+          sleep 5;
+        done


### PR DESCRIPTION
Issue: [OS-668](https://scality.atlassian.net/browse/OS-668)

The `delay-job-completion` action is intended to be paired with the `ssh-to-worker` action in order to sleep and prevent a job from completing and being torn down.

There is no point in sleeping if the tmate process has been killed and a developer can no longer connect to the job.

This adds adds a check for tmate's PID in the action's sleep loop.

[OS-668]: https://scality.atlassian.net/browse/OS-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ