### PR TITLE
pre-create waterfall branches in bump version action

### DIFF
--- a/xcore/bump_version_pull_request/action.yaml
+++ b/xcore/bump_version_pull_request/action.yaml
@@ -29,7 +29,7 @@ runs:
     - name: install semver
       shell: bash
       run: |
-        curl --fail -LO https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
+        curl -s --fail -LO https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
         chmod +x ./semver
     - name: extract version
       shell: bash
@@ -46,22 +46,12 @@ runs:
     - name: push changes
       shell: bash
       run: |
-        NEW_VERSION=${{ steps.bumped-version.outputs.new_version }}
-        git checkout -b feature/bump_version_${NEW_VERSION} ${{ github.ref }}
+        ${GITHUB_ACTION_PATH}/push_new_version.sh \
+          ${{ github.actor }} \
+          ${{ github.ref }} \
+          ${{ steps.version.outputs.VERSION }} \
+          ${{ steps.bumped-version.outputs.new_version }}
 
-        # update version patch level
-        sed -i "s/VERSION=.*/VERSION=${NEW_VERSION}/" ./VERSION
-
-        git add ./VERSION
-
-        # config git to commit
-        git config --local user.name ${{ github.actor }}
-        git config --local user.email ${{ github.actor }}@scality.com
-
-        # commit changes
-        git commit -m "Bump version to ${NEW_VERSION}"
-
-        git push --set-upstream origin feature/bump_version_${NEW_VERSION}
     - name: Open pr
       id: pull-request
       shell: bash

--- a/xcore/bump_version_pull_request/push_new_version.sh
+++ b/xcore/bump_version_pull_request/push_new_version.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -e
+
+if [[ $# != 4 ]]; then
+    echo "usage: $0 <github actor> <github_ref> <version> <version_bumped>"
+    exit 1
+fi
+
+GITHUB_ACTOR=$1
+REF=$2
+VERSION=$3
+NEW_VERSION=$4
+git fetch --all --unshallow
+
+git checkout -b feature/bump_version_${NEW_VERSION} ${REF}
+
+# update version patch level
+sed -i "s/VERSION=.*/VERSION=${NEW_VERSION}/" ./VERSION
+
+git add ./VERSION
+
+# config git to commit
+git config --local user.name ${GITHUB_ACTOR}
+git config --local user.email ${GITHUB_ACTOR}@scality.com
+
+# commit changes
+git commit -m "Bump version to ${NEW_VERSION}"
+
+# fetch all branches
+all_dev_branches=$(git branch --all | grep -E 'origin/development/' | grep -v HEAD | sed 's_remotes/origin/development/__' | sort -u | tr -s '\n' ' ')
+short_version=$(./semver get major ${VERSION}).$(./semver get minor  ${VERSION})
+
+echo "Find upper branches in: ${all_dev_branches}"
+echo "based on current branch: ${short_version}"
+
+# Identify the upper version branches
+upper_branches=""
+for branch in ${all_dev_branches}; do
+    is_upper=$(./semver compare "${branch}.0" "${short_version}.0")
+    if [[ "${is_upper}" -gt 0 ]]; then
+        upper_branches="${upper_branches}${branch} "
+    fi
+done
+
+echo "Prepare waterfall branches for: ${upper_branches}"
+base_branch="feature/bump_version_${NEW_VERSION}"
+
+for branch in ${upper_branches}; do
+    echo "Create and push waterfall branch for origin/development/${branch}"
+    git checkout -B w/${branch}/feature/bump_version_${NEW_VERSION} origin/development/${branch}
+
+    # We now we can always use 'ours' as this sould only update the version file for the current branch only
+    git merge --strategy=ours --no-edit ${base_branch}
+
+    git push -u origin w/${branch}/feature/bump_version_${NEW_VERSION}
+    base_branch="w/${branch}/feature/bump_version_${NEW_VERSION}"
+done
+
+# don't forget to checkout the original branch too
+git checkout feature/bump_version_${NEW_VERSION}
+git push --set-upstream origin feature/bump_version_${NEW_VERSION}


### PR DESCRIPTION
By creating the waterfall branches in bump version we ensure when opening the PR that bert-e is already happy and we don't need to solve conflict ourselves knowing that we don't want to keep the upade as the update only contains the version bump for version x.y and we try to merge in upper version branches wo th version is already x+1.y+1 and we don't want to forward-port this change.