### PR TITLE
delay-job-completion: fix help message

### DIFF
--- a/action-delay-job-completion/action.yaml
+++ b/action-delay-job-completion/action.yaml
@@ -22,9 +22,6 @@ runs:
         EOF
         )
         echo "::notice title=Delay workflow completion::${MESSAGE}"
-        Delete the file '$GITHUB_WORKSPACE/timeout_date' to cancel.
-        You can update that file with:
-          date '+%s' --date='now + <X> minutes' > $GITHUB_WORKSPACE/timeout_date to change the delay."
 
         date '+%s' --date='now + ${{ inputs.completion_delay_m }} minutes' > $GITHUB_WORKSPACE/timeout_date
         while [ $(date '+%s') -lt $(cat $GITHUB_WORKSPACE/timeout_date 2>/dev/null || echo 0) ] && [[ -f /tmp/tmate.pid ]] && ps --pid $(cat /tmp/tmate.pid) &>/dev/null ;


### PR DESCRIPTION
We're currently facing
```
Notice: --------------------------------------------------
Sleeping for 30 minutes.
To cancel, delete the file '/home/runner/work/ring/ring/timeout_date' or end the debugging session.
To change the delay duration, update the file '/home/runner/work/ring/ring/timeout_date' with:
  date '+%s' --date='now + <X> minutes' > /home/runner/work/ring/ring/timeout_date ."
--------------------------------------------------
/home/runner/work/_temp/ca5a77ac-482f-47fc-83ac-876c2bbf4a8d.sh: line 11: Delete: command not found
Error: Process completed with exit code 127.
```