### PR TITLE
different install method for tmate

### DIFF
--- a/.github/workflows/ssh-runner.yaml
+++ b/.github/workflows/ssh-runner.yaml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         name:
         - ubuntu-latest
-        - centos7
         - redhat8
         - rocky8
     runs-on: ${{ matrix.name }}

--- a/action-ssh-to-runner/action.yaml
+++ b/action-ssh-to-runner/action.yaml
@@ -30,13 +30,7 @@ runs:
         cat ${TMATE_CONF}
     - name: "SSH to runner: Install tmate"
       shell: bash
-      run: |
-        TMATE_VERSION=2.4.0
-        ARCH=amd64
-        wget https://github.com/tmate-io/tmate/releases/download/${TMATE_VERSION}/tmate-${TMATE_VERSION}-static-linux-${ARCH}.tar.xz -P /tmp
-        tar -xf /tmp/tmate-${TMATE_VERSION}-static-linux-${ARCH}.tar.xz -C /tmp
-        TMATE_BIN=/tmp/tmate-${TMATE_VERSION}-static-linux-${ARCH}/tmate
-        echo "TMATE_BIN=$TMATE_BIN" >> $GITHUB_ENV
+      run: ${GITHUB_ACTION_PATH}/install-tmate.sh
     - name: "SSH to runner: Set up scripts"
       shell: bash
       run: |
@@ -52,15 +46,15 @@ runs:
       run: |
         TMATE_SOCK=/tmp/tmate.sock
         echo "TMATE_SOCK=$TMATE_SOCK" >> $GITHUB_ENV
-        nohup ${{ env.TMATE_BIN }} -f ${{ env.TMATE_CONF }} -S ${TMATE_SOCK} -F > /dev/null &
+        nohup tmate -f ${{ env.TMATE_CONF }} -S ${TMATE_SOCK} -F > /dev/null &
         echo "$!" > /tmp/tmate.pid
         # We need to wait a bit for tmate to start.
         sleep 5
-        ${{ env.TMATE_BIN }} -f ${{ env.TMATE_CONF }} -S ${TMATE_SOCK} wait tmate-ready
+        tmate -f ${{ env.TMATE_CONF }} -S ${TMATE_SOCK} wait tmate-ready
     - name: "SSH to runner: Pause workflow and print connection instructions"
       shell: bash
       run: |
-        TMATE_SSH=$(${{ env.TMATE_BIN }} -f ${{ env.TMATE_CONF }} -S ${{ env.TMATE_SOCK }} display -p '#{tmate_ssh}')
+        TMATE_SSH=$(tmate -f ${{ env.TMATE_CONF }} -S ${{ env.TMATE_SOCK }} display -p '#{tmate_ssh}')
         MESSAGE=$(cat << EOF
 
         --------------------------------------------------

--- a/action-ssh-to-runner/install-tmate.sh
+++ b/action-ssh-to-runner/install-tmate.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+source /etc/os-release
+
+# Check if tmate is installed
+if ! command -v tmate &> /dev/null; then
+  echo "tmate is not installed"
+else
+  echo "tmate is already installed"
+  exit 0
+fi
+
+# If os is ubuntu or debian
+if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
+    sudo apt-get update
+    sudo apt-get install -y tmate
+# if os is rocky, centos or redhat
+elif [[ $ID == "rocky" || $ID == "centos" || $ID == "rhel" ]]; then
+    if [[ ${VERSION_ID:0:1} -ge 8 ]]; then
+        sudo dnf install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${VERSION_ID:0:1}.noarch.rpm"
+        sudo dnf install -y tmate
+    else
+        sudo yum install -y epel-release
+        sudo yum install -y tmate
+    fi
+else
+  echo "Unsupported OS"
+  exit 1
+fi


### PR DESCRIPTION
Found some related information regarding freezes on tmate due to binary available on the release page of the repo: https://github.com/tmate-io/tmate/issues/267

Now changing the installation method for those as recommended inside the issue in the hope that it may help in some of our experiences with the tool.