### PR TITLE
PTFE-2872: Add run-id output to retry-workflow action

### DIFF
--- a/action-retry-workflow/README.md
+++ b/action-retry-workflow/README.md
@@ -83,6 +83,7 @@ jobs:
           echo "Workflow status: ${{ steps.retry.outputs.status }}"
           echo "Retry count: ${{ steps.retry.outputs.retry-count }}"
           echo "Was retried: ${{ steps.retry.outputs.was-retried }}"
+          echo "Run ID: ${{ steps.retry.outputs.run-id }}"
 
       - name: Notify on retry
         if: steps.retry.outputs.was-retried == 'true'
@@ -189,6 +190,7 @@ You can optionally filter retries to only trigger when a specific job or step fa
 | `status` | Current status/conclusion of the workflow | `success`, `failure`, `cancelled`, `timed_out`, `not_found` |
 | `retry-count` | Number of retries performed | `0`, `1`, `2` |
 | `was-retried` | Whether the workflow was retried by this action | `true`, `false` |
+| `run-id` | The workflow run ID that was checked/retried | `12345678`, `87654321` |
 
 ## Step Summary
 

--- a/action-retry-workflow/action.yaml
+++ b/action-retry-workflow/action.yaml
@@ -45,6 +45,9 @@ outputs:
   was-retried:
     description: 'Whether the workflow was retried by this action (true/false)'
     value: ${{ steps.retry.outputs.was_retried }}
+  run-id:
+    description: 'The workflow run ID that was checked/retried'
+    value: ${{ steps.retry.outputs.run_id }}
 
 runs:
   using: composite

--- a/action-retry-workflow/retry_workflow.py
+++ b/action-retry-workflow/retry_workflow.py
@@ -601,7 +601,8 @@ class RetryOutputWriter:
         output_file: Optional[str],
         status: str,
         retry_count: int,
-        was_retried: bool
+        was_retried: bool,
+        run_id: Optional[int] = None
     ) -> None:
         """
         Write output variables for GitHub Actions.
@@ -611,11 +612,13 @@ class RetryOutputWriter:
             status: Workflow status
             retry_count: Number of retries performed
             was_retried: Whether retry was triggered
+            run_id: Workflow run ID (optional)
         """
         variables = {
             "status": status,
             "retry_count": str(retry_count),
-            "was_retried": "true" if was_retried else "false"
+            "was_retried": "true" if was_retried else "false",
+            "run_id": str(run_id) if run_id else ""
         }
 
         if output_file:
@@ -838,7 +841,8 @@ def main() -> int:
             args.output_file,
             result["status"],
             result["retry_count"],
-            result["was_retried"]
+            result["was_retried"],
+            result["run_id"]
         )
 
         RetryOutputWriter.write_step_summary(
@@ -849,7 +853,7 @@ def main() -> int:
             result["was_retried"],
             args.max_retries,
             args.retry_mode,
-            result.get("run_id")
+            result["run_id"]
         )
 
         return 0


### PR DESCRIPTION
Expose the workflow run ID as an output variable to allow workflows to reference the specific run being checked/retried.