### PR TITLE
improvement(PTFE-3166): update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -9,7 +9,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: create fake version file
         run: |
           echo "VERSION=1.2.3" > VERSION

--- a/.github/workflows/crons-tests.yaml
+++ b/.github/workflows/crons-tests.yaml
@@ -7,7 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./action-crons
         with:
            event_schedule: 'now'

--- a/.github/workflows/docker-upload.yaml
+++ b/.github/workflows/docker-upload.yaml
@@ -7,7 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./actions-docker-upload
         with:
           name: 'test'

--- a/.github/workflows/openstack-cleanup.yaml
+++ b/.github/workflows/openstack-cleanup.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cleanup OpenStack VMs
         uses: ./actions-cleanup-openstack-vms
         with:

--- a/.github/workflows/ssh-runner.yaml
+++ b/.github/workflows/ssh-runner.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: ssh
       uses: ./action-ssh-to-runner
       with:

--- a/.github/workflows/test-retry-workflow.yaml
+++ b/.github/workflows/test-retry-workflow.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 


### PR DESCRIPTION
## Summary
Update GitHub Actions workflow files to use action versions running on Node 24.

Closes PTFE-3166

## Context
GitHub is deprecating Node 20 as the JavaScript runtime for GitHub Actions runners:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

- June 2, 2026: Runners default to Node 24
- Fall 2026: Node 20 completely removed

## Changes
Updated action versions to Node 24-compatible: actions/checkout@v4→@v6, etc.