### PR TITLE
RING-54657: sync arti_compute.py with RING and add unit tests

### DIFF
--- a/.github/workflows/test-arti-compute.yaml
+++ b/.github/workflows/test-arti-compute.yaml
@@ -11,6 +11,43 @@ on:
       - '.github/workflows/test-arti-compute.yaml'
 
 jobs:
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r arti-compute/requirements-dev.txt
+
+      - name: Run pytest
+        run: python -m pytest arti-compute/test_arti_compute.py -v
+
+  lint:
+    name: flake8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Run flake8
+        working-directory: arti-compute
+        run: python -m flake8 .
+
   check-tech-train:
     name: Smoke check-tech-train
     runs-on: ubuntu-latest

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,4 @@
 * @scality/platform-eng
+
+/arti-compute/ @scality/supsetup
+/.github/workflows/test-arti-compute.yaml @scality/supsetup

--- a/arti-compute/.flake8
+++ b/arti-compute/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/arti-compute/arti_compute.py
+++ b/arti-compute/arti_compute.py
@@ -145,6 +145,24 @@ def is_scality_managed_os(os_name):
     """Check if OS is a Scality-managed image (scalityos or adi)"""
     return bool(SCALITYOS_VERSION_REGEX.match(os_name) or ADI_OS_REGEX.match(os_name))
 
+
+def _split_os_minor(os_name):
+    """Split an OS name into its major-only form and optional minor version.
+
+    Examples:
+        rhel9.6 -> ('rhel9', '9.6')
+        rhel9   -> ('rhel9', None)
+        rocky9  -> ('rocky9', None)
+    scalityos/adi names are returned unchanged, with no minor.
+    """
+    if is_scality_managed_os(os_name):
+        return os_name, None
+    m = re.match(r'^(?P<base>[a-zA-Z]+\d+)\.(?P<minor>\d+)$', os_name)
+    if not m:
+        return os_name, None
+    major = re.search(r'\d+$', m.group('base')).group(0)
+    return m.group('base'), f"{major}.{m.group('minor')}"
+
 # Architecture (1st one is the default)
 ARCHITECTURE = (
     '1site_3nodes_s3_sofs',
@@ -281,6 +299,10 @@ class ArtiCompute:
                  upgrade_from_version=None, architecture=ARCHITECTURE[0], suffix=None, region=None,
                  adi_artifact=None, github_token=None, ring_explicit=False,
                  adi_upgrade_from_version=None, adi_branch=None):
+        # Accept an optional OS minor (e.g. rhel9.6): keep os_name major-only
+        # for installer/S3/validity logic, and remember the minor so snapshot
+        # selection can pick the closest matching minor (see _select_snapshot).
+        os_name, self.os_minor = _split_os_minor(os_name)
         if not is_valid_os(os_name):
             raise ValueError(f"Unknown OS name '{os_name}'")
 
@@ -437,7 +459,7 @@ class ArtiCompute:
                         self.os_name, self.offline, auth=self.auth)
                     self._upgrade_snapshot = self._find_snapshot(
                         self._ring_upgrade_from, self.os_name,
-                        self.nb_nodes, self.suffix)
+                        self.nb_nodes, self.suffix, os_minor=self.os_minor)
                 except (ArtifactError, VersionError):
                     if 'upgrade' in self.jobs:
                         raise
@@ -463,7 +485,8 @@ class ArtiCompute:
                                 ring_installer=self._ring_upgrade_from,
                                 os_name=self.os_name,
                                 nb_nodes=self.nb_nodes,
-                                snapshot_suffix=self.suffix)
+                                snapshot_suffix=self.suffix,
+                                os_minor=self.os_minor)
                             break
                         except (ArtifactError, VersionError) as err:
                             if self._is_released_GA(err.version or upgrade_from):
@@ -505,7 +528,7 @@ class ArtiCompute:
                         self.os_name, self.offline, auth=self.auth)
                 self._upgrade_snapshotprev = self._find_snapshot(
                     self._ring_upgradeprev_from, self.os_name,
-                    self.nb_nodes, self.suffix)
+                    self.nb_nodes, self.suffix, os_minor=self.os_minor)
         except (ArtifactError, VersionError):
             if 'upgradeprev' in self.jobs:
                 raise   # Problem only if upgradeprev job is requested
@@ -739,8 +762,16 @@ class ArtiCompute:
 
     @classmethod
     def _find_snapshot(cls, ring_installer, os_name, nb_nodes=3,
-                       architecture=None, snapshot_suffix=None, region=None):
-        """Find snapshot name from given RING installer URL"""
+                       architecture=None, snapshot_suffix=None, region=None,
+                       os_minor=None):
+        """Find snapshot name from given RING installer URL.
+
+        Snapshot selection is OS-minor aware (see _select_snapshot):
+          - os_minor set (e.g. '9.6'): pick the highest available minor that
+            is <= the requested minor, or None if none qualifies;
+          - os_minor None (major-only request): pick the highest available
+            minor.
+        """
         if not is_valid_os(os_name):
             raise ValueError(f"Unknown OS name '{os_name}'")
 
@@ -770,13 +801,16 @@ class ArtiCompute:
         if not architecture:
             architecture = ARCHITECTURE[0]
 
+        # Do NOT filter on os_version here: snapshots are tagged with their
+        # full OS version, which may be a bare major (e.g. "9") or a
+        # major.minor (e.g. "9.7"). We want every available minor so that
+        # _select_snapshot can pick the closest one <= the requested minor.
         # First try with architecture, if not found, try with nb_nodes
         for extra_filters in (('ring_architecture', architecture), ('nb_storage_server', str(nb_nodes))):
             snapshots = get_snapshots(
                 custom_filters=[
                     ('ring_version', ring_version),
                     ('os_name', name),
-                    ('os_version', version),
                     ('owner', 'ci'),
                     extra_filters,
                 ],
@@ -787,15 +821,54 @@ class ArtiCompute:
 
         if not snapshot_suffix:
             snapshot_suffix = DEFAULT_SUFFIX
-        reSnapshot = re.compile(rf'^RING-{ring_version}-.+?\[{snapshot_suffix}]$')
 
+        snapshot = cls._select_snapshot(
+            snapshots, ring_version, name, version, os_minor, snapshot_suffix)
+        if snapshot:
+            logger.debug(f"Found {os_name} snapshot {snapshot} for RING {ring_version}")
+        else:
+            logger.debug(f"No {os_name} snapshot found for RING {ring_version}")
+        return snapshot
+
+    @classmethod
+    def _select_snapshot(cls, snapshots, ring_version, os_family, os_major,
+                         os_minor, snapshot_suffix):
+        """Pick the best snapshot for the requested OS minor version.
+
+        Snapshot names look like:
+            RING-<ring_version>-<os_family><os_version>-<n>nodes[<suffix>]
+        where <os_version> is a major ("9") or major.minor ("9.7").
+
+        Selection rules for the requested OS (os_major[.os_minor]):
+          - os_minor given: choose the highest available minor that is
+            <= the requested minor; return None if none qualifies (never
+            pick a higher minor, i.e. never "downgrade" the request);
+          - os_minor None (major-only request): choose the highest
+            available minor.
+        A snapshot tagged with a bare major (no minor) is treated as
+        minor 0, so it stays eligible as a last-resort fallback.
+        """
+        reSnapshot = re.compile(
+            rf'^RING-{re.escape(ring_version)}-{re.escape(os_family)}'
+            rf'(?P<osver>\d+(?:\.\d+)?)-.+?\[{re.escape(snapshot_suffix)}]$')
+
+        target_major = int(os_major)
+        target_minor = int(os_minor.split('.')[1]) if os_minor else None
+
+        best = None     # (minor, name)
         for snapshot in snapshots:
-            if reSnapshot.match(snapshot):
-                logger.debug(f"Found {os_name} snapshot {snapshot} for RING {ring_version}")
-                return snapshot
-
-        logger.debug(f"No {os_name} snapshot found for RING {ring_version}")
-        return None
+            m = reSnapshot.match(snapshot)
+            if not m:
+                continue
+            osver = m.group('osver').split('.')
+            if int(osver[0]) != target_major:
+                continue
+            minor = int(osver[1]) if len(osver) > 1 else 0
+            if target_minor is not None and minor > target_minor:
+                continue    # never pick a higher minor than requested
+            if best is None or minor > best[0]:
+                best = (minor, snapshot)
+        return best[1] if best else None
 
     @classmethod
     def _find_adi_snapshot(cls, adi_version, nb_nodes=3,
@@ -1780,13 +1853,13 @@ def get_options():
     """Parse and return command line arguments."""
 
     def _fix_os_name(string):
-        """Fix RHEL name if needed, change OSmajor.minor to OSmajor"""
-        reMajorMinor = re.compile(r'^(\D+?\d+)(\.\d+)?$')
-        m = reMajorMinor.match(string)
-        if m:
-            string = m.group(1)
-        string = string.lower()
-        return string.replace('redhat', 'rhel')
+        """Normalize OS name: lowercase and map redhat->rhel.
+
+        The OS minor version (e.g. rhel9.6) is preserved: snapshot selection
+        needs it (see ArtiCompute._select_snapshot). Stripping to major-only
+        is done later, where a major-only name is required.
+        """
+        return string.lower().replace('redhat', 'rhel')
 
     def _check_version(string):
         """Check version format"""
@@ -1799,9 +1872,10 @@ def get_options():
         description='Compute artifact input data for installer tests workflow'
     )
     def _validate_os(os_name):
-        """Validate OS name, accepting scalityos variants"""
+        """Validate OS name, accepting scalityos variants and an OS minor"""
         os_name = _fix_os_name(os_name)
-        if not is_valid_os(os_name):
+        major_os, _ = _split_os_minor(os_name)
+        if not is_valid_os(major_os):
             raise argparse.ArgumentTypeError(
                 f"Invalid OS '{os_name}'."
             )

--- a/arti-compute/arti_compute.py
+++ b/arti-compute/arti_compute.py
@@ -713,20 +713,22 @@ class ArtiCompute:
             if is_previous and from_version < [8, 0, 0, 0]:
                 raise Unsupported("Rocky8 upgradeprev only supported from 9.0.0.0")
         elif self.os_name == 'rhel9':
-            # RedHat9 can upgrade only after 9.3.0.0 and upgrade-prev after ??
+            # RedHat9 can upgrade only after 9.3.0.0
             if version < [9, 3, 0, 0]:
                 raise Unsupported("RHEL9 upgrade only supported from 9.3.0.0")
-            # if is_previous and from_version < [8, 0, 0, 0]:
-            #     raise UnsupportedUpgrade("RHEL8 upgradeprev only supported from 9.0.0.0")
-            if is_previous:
+            # upgradeprev on RING 9 targets RING 8, which has no RHEL9 image;
+            # from RING 10 the previous tech-train is 9.5.2 (RHEL9-capable),
+            # so upgradeprev is valid there.
+            if is_previous and version[0] < 10:
                 raise Unsupported("RHEL9 upgradeprev not supported")
         elif self.os_name == 'rocky9':
-            # Rocky9 can upgrade only after 9.4.0.0 and upgrade-prev after ??
+            # Rocky9 can upgrade only after 9.4.0.0
             if version < [9, 4, 0, 0]:
                 raise Unsupported("Rocky9 upgrade only supported from 9.4.0.0")
-            # if is_previous and from_version < [8, 0, 0, 0]:
-            #     raise UnsupportedUpgrade("Rocky8 upgradeprev only supported from 9.0.0.0")
-            if is_previous:
+            # upgradeprev on RING 9 targets RING 8, which has no Rocky9 image;
+            # from RING 10 the previous tech-train is 9.5.2 (Rocky9-capable),
+            # so upgradeprev is valid there.
+            if is_previous and version[0] < 10:
                 raise Unsupported("Rocky9 upgradeprev not supported")
         elif is_scality_managed_os(self.os_name):
             if from_version < [10, 0, 0, 0]:

--- a/arti-compute/arti_compute.py
+++ b/arti-compute/arti_compute.py
@@ -180,6 +180,7 @@ TECH_TRAIN = {
     'previous-9.5.1': '8.5.12',
     'previous-9.5.2': '8.5.12',
     'previous-9.5.3': '8.5.12',
+    'previous-9.5.4': '8.5.12',
 
     'previous-10.0.0': '9.5.2',
     'previous-10.1.0': '9.5.2',

--- a/arti-compute/arti_compute.py
+++ b/arti-compute/arti_compute.py
@@ -105,7 +105,7 @@ JOB_TYPE = ("install", "upgrade", "upgradeprev", "sbom")
 # RING previous version types
 VERSION_TYPE = ("stable", "current", "previous")
 
-_ring_major =  _get_ring_major()
+_ring_major = _get_ring_major()
 
 # NOTE: ADD_NEW_OS (do not remove)
 OS = ()
@@ -118,13 +118,16 @@ if _ring_major > 9:
 if _ring_major < 10:
     OS += ("rhel8", "rocky8")
 
-SCALITYOS_VERSION_REGEX= re.compile(
+# scalityos or scalityos-X.Y or scalityos-X.Y-N or scalityos-X.Y-N.build_id
+SCALITYOS_VERSION_REGEX = re.compile(
   r'^(?P<name>scalityos)(-(?P<ver>\d+[.]\d+(-\d+([.][a-f0-9]{8})?)?))?$'
-) # scalityos or scalityos-X.Y or scalityos-X.Y-N or scalityos-X.Y-N.build_id
+)
 
+# adi-X.Y.Z or adi-X.Y.Z.SHA or adi-X.Y.Z_pwN or adi-X.Y.Z_rcN
 ADI_OS_REGEX = re.compile(
   r'^(?P<name>adi)-(?P<ver>\d+\.\d+\.\d+([.][a-f0-9]+|_(rc|pw)\d+)?)$'
-) # adi-X.Y.Z or adi-X.Y.Z.SHA or adi-X.Y.Z_pwN or adi-X.Y.Z_rcN
+)
+
 
 def is_valid_os(os_name):
     """
@@ -140,6 +143,7 @@ def is_valid_os(os_name):
         return True
     logger.warning(f"Unknown OS name '{os_name}'")
     return False
+
 
 def is_scality_managed_os(os_name):
     """Check if OS is a Scality-managed image (scalityos or adi)"""
@@ -162,6 +166,7 @@ def _split_os_minor(os_name):
         return os_name, None
     major = re.search(r'\d+$', m.group('base')).group(0)
     return m.group('base'), f"{major}.{m.group('minor')}"
+
 
 # Architecture (1st one is the default)
 ARCHITECTURE = (
@@ -221,6 +226,7 @@ DEFAULT_SUFFIX = 'GA'
 # or OS+version combination is not supported
 UNSUPPORTED = "__UNSUPPORTED__"
 
+
 class ArtifactError(Exception):
     """Artifact related error"""
     def __init__(self, message, version=None):
@@ -273,7 +279,7 @@ def get_snapshots(region=None, custom_filters=None, filter_supervisor=True):
             filters.append({'Name': 'tag:' + tag, 'Values': [value]})
 
     # Set filter on supervisor
-    if filter_supervisor == True:
+    if filter_supervisor:
         filters.append({'Name': 'tag:type', 'Values': ['supervisor']})
 
     try:
@@ -781,7 +787,7 @@ class ArtiCompute:
             name = m.group('name')
             version = m.group('ver')
             if not version:
-                logger.warning(f"Snapshot not supported when a specific scalityos version is not provided")
+                logger.warning("Snapshot not supported when a specific scalityos version is not provided")
                 return None
         else:
             m = re.match(r'(?P<name>.+?)(?P<ver>\d+)', os_name)
@@ -789,7 +795,7 @@ class ArtiCompute:
             version = m.group('ver')
         ring_version = cls._get_ring_version(ring_installer)
 
-        msg =  [f"Searching {os_name} RING {ring_version} {nb_nodes} nodes snapshot" ]
+        msg = [f"Searching {os_name} RING {ring_version} {nb_nodes} nodes snapshot"]
         if architecture:
             msg.append(f"architecture={architecture}")
         if snapshot_suffix:
@@ -933,7 +939,7 @@ class ArtiCompute:
                 ring_os_name = f"{m.group('name')}_{m.group('ver')}"
             installer_suffix = f"{ring_os_name}.run"
             reRingInstaller = re.compile(rf'^scality-ring-.+?{installer_suffix}$')
-            reAnyInstaller = re.compile(rf'^scality-ring-.+?\.run$')
+            reAnyInstaller = re.compile(r'^scality-ring-.+?\.run$')
 
             response = requests.get(
                 os.path.join(base_url, 'installer', '?format=txt'),
@@ -1117,7 +1123,8 @@ class ArtiCompute:
         last_installer, _ = cls._find_ring_installer(
             os.path.join(build_url, last_stable), os_name, auth=auth)
         if last_installer is None:
-            raise ArtifactError(f"No RING installer found for '{last_stable}'", version=cls._get_ring_version(last_stable))
+            raise ArtifactError(f"No RING installer found for '{last_stable}'",
+                                version=cls._get_ring_version(last_stable))
         logger.debug(f"Found {os_name} last stable RING {last_stable} installer: {last_installer}")
         return last_installer
 
@@ -1165,7 +1172,8 @@ class ArtiCompute:
                 os.path.join(base_s3_url, buildid), os_name, offline, auth=auth)
             try:    # For error message...
                 s3_version = cls._get_s3_version(buildid)
-                logger.debug(f"Using {os_name} latest S3 {s3_version} installer {last_installer} (provided by {buildid})")
+                logger.debug(f"Using {os_name} latest S3 {s3_version} installer "
+                             f"{last_installer} (provided by {buildid})")
             except VersionError:
                 s3_version = ""
         else:
@@ -1199,10 +1207,10 @@ class ArtiCompute:
             else:
                 # Found nothing, search artifacts
                 latest_version = {
-                    'LAST' : None,
-                    'LAST_PW' : None,
-                    'LAST_RC' : None,
-                    'LAST_GA' : None,
+                    'LAST': None,
+                    'LAST_PW': None,
+                    'LAST_RC': None,
+                    'LAST_GA': None,
                 }
                 response = requests.get(
                     os.path.join(DEFAULT_ARTIFACT_URL, '?format=txt'),
@@ -1836,12 +1844,12 @@ class ArtiCompute:
                     and self.jobs[0] == 'upgradeprev'
                     and normalize):
                 print(file=outfile)
-                print(f"# ==== Normalize upgradeprev to upgrade", file=outfile)
-                print(f"UPGRADE_INSTALLER_RING=$UPGRADEPREV_INSTALLER_RING", file=outfile)
-                print(f"UPGRADE_INSTALLER_S3=$UPGRADEPREV_INSTALLER_S3", file=outfile)
-                print(f"UPGRADE_RING_VERSION=$UPGRADEPREV_RING_VERSION", file=outfile)
-                print(f"UPGRADE_S3_VERSION=$UPGRADEPREV_S3_VERSION", file=outfile)
-                print(f"UPGRADE_FROM_SNAPSHOT=$UPGRADEPREV_FROM_SNAPSHOT", file=outfile)
+                print("# ==== Normalize upgradeprev to upgrade", file=outfile)
+                print("UPGRADE_INSTALLER_RING=$UPGRADEPREV_INSTALLER_RING", file=outfile)
+                print("UPGRADE_INSTALLER_S3=$UPGRADEPREV_INSTALLER_S3", file=outfile)
+                print("UPGRADE_RING_VERSION=$UPGRADEPREV_RING_VERSION", file=outfile)
+                print("UPGRADE_S3_VERSION=$UPGRADEPREV_S3_VERSION", file=outfile)
+                print("UPGRADE_FROM_SNAPSHOT=$UPGRADEPREV_FROM_SNAPSHOT", file=outfile)
                 print("unset UPGRADEPREV_INSTALLER_RING", file=outfile)
                 print("unset UPGRADEPREV_INSTALLER_S3", file=outfile)
                 print("unset UPGRADEPREV_RING_VERSION", file=outfile)
@@ -1871,6 +1879,7 @@ def get_options():
     parser = argparse.ArgumentParser(
         description='Compute artifact input data for installer tests workflow'
     )
+
     def _validate_os(os_name):
         """Validate OS name, accepting scalityos variants and an OS minor"""
         os_name = _fix_os_name(os_name)

--- a/arti-compute/arti_compute.py
+++ b/arti-compute/arti_compute.py
@@ -1219,13 +1219,13 @@ class ArtiCompute:
                 if not response.ok:
                     raise ArtifactError(f"_find_latest_s3_installer(): {response.reason} ({response.status_code})")
                 reS3Version = re.compile(
-                    rf'github:scality:[fF]ederation:staging-{s3_version}([.](\d+[.]?){0,3})?.+[.]build[.].+$')
+                    rf'github:scality:[fF]ederation:staging-{s3_version}([.](\d+[.]?){{0,3}})?.+[.]build[.].+$')
                 reS3VersionGA = re.compile(
-                    rf'github:scality:[fF]ederation:promoted-{s3_version}([.](\d+[.]?){0,3})?/$')
+                    rf'github:scality:[fF]ederation:promoted-{s3_version}([.](\d+[.]?){{0,3}})?/$')
                 reS3VersionRC = re.compile(
-                    rf'github:scality:[fF]ederation:promoted-{s3_version}([.](\d+[.]?){0,3})?_rc.+$')
+                    rf'github:scality:[fF]ederation:promoted-{s3_version}([.](\d+[.]?){{0,3}})?_rc.+$')
                 reS3VersionPW = re.compile(
-                    rf'github:scality:[fF]ederation:promoted-{s3_version}([.](\d+[.]?){0,3})?_pw.+$')
+                    rf'github:scality:[fF]ederation:promoted-{s3_version}([.](\d+[.]?){{0,3}})?_pw.+$')
                 for line in response.text.splitlines():
                     if reS3Version.match(line):
                         latest_version['LAST'] = line

--- a/arti-compute/conftest.py
+++ b/arti-compute/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest setup for the arti-compute unit tests.
+
+``arti_compute`` resolves the RING VERSION file at import time (module-level
+``_ring_major``), which outside a RING checkout would fail. Point it at the
+bundled testdata VERSION before any test module imports it.
+"""
+import os
+
+os.environ.setdefault(
+    'RING_VERSION_FILE',
+    os.path.join(os.path.dirname(__file__), 'testdata', 'VERSION'),
+)

--- a/arti-compute/requirements-dev.txt
+++ b/arti-compute/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/arti-compute/requirements-dev.txt
+++ b/arti-compute/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
+flake8
 pytest

--- a/arti-compute/test_arti_compute.py
+++ b/arti-compute/test_arti_compute.py
@@ -137,6 +137,20 @@ def _select(snapshots, os_minor, os_major="9", family="redhat", suffix=SUFFIX):
         snapshots, RING, family, os_major, os_minor, suffix)
 
 
+# OS tuple is built from _ring_major; assert each OS's membership against the
+# _ring_major resolved at import (testdata/VERSION via conftest.py) so this
+# stays correct whichever RING version the action is pinned to.
+@pytest.mark.parametrize("os_name,expected_present", [
+    ("rhel9", ac._ring_major > 8),
+    ("rocky9", ac._ring_major > 8),
+    ("scalityos", ac._ring_major > 9),
+    ("rhel8", ac._ring_major < 10),
+    ("rocky8", ac._ring_major < 10),
+])
+def test_os_tuple_gating(os_name, expected_present):
+    assert (os_name in ac.OS) is expected_present
+
+
 class TestSplitOsMinor:
     def test_with_minor(self):
         assert _split_os_minor("rhel9.6") == ("rhel9", "9.6")

--- a/arti-compute/test_arti_compute.py
+++ b/arti-compute/test_arti_compute.py
@@ -1,14 +1,130 @@
-"""Unit tests for arti_compute OS-minor-aware snapshot selection (RING-54644)."""
+#!/usr/bin/env python3
+"""Pure unit tests for arti_compute.py: upgrade/upgradeprev support matrix,
+OS-tuple gating, and OS-minor-aware snapshot selection.
+
+Table-driven, no network / AWS / artifact lookups: instances are built with
+``__new__`` and only the attributes the tested helper reads are set, so
+``__init__`` never runs, and the snapshot selector is a pure classmethod called
+directly. Every OS, version and snapshot is passed explicitly, so the file
+is independent of the RING branch the script was taken from.
+"""
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.dirname(__file__))
 
-from arti_compute import ArtiCompute, _split_os_minor   # noqa: E402
+import arti_compute as ac                                # noqa: E402
+from arti_compute import ArtiCompute, _split_os_minor    # noqa: E402
 
 
 RING = "9.5.2.5"
 SUFFIX = "GA"
+
+
+def _ac(os_name, ring_version):
+    """Build a minimal ArtiCompute instance without running __init__."""
+    obj = ArtiCompute.__new__(ArtiCompute)
+    obj.os_name = os_name
+    obj._ring_installer = f"scality-ring-{ring_version}.run"
+    obj._adi_ring_version = None
+    return obj
+
+
+def _upgrade_supported(os_name, to_version, from_version, is_previous):
+    try:
+        _ac(os_name, to_version).is_valid_upgrade(
+            from_version, is_previous=is_previous)
+        return True
+    except ac.Unsupported:
+        return False
+
+
+# The workflow passes minor-qualified --os names (redhat8.10, redhat9.7, ...).
+# get_options._fix_os_name lowercases and maps redhat->rhel but keeps minor;
+# ArtiCompute.__init__ splits it (_split_os_minor) into a major-only os_name
+# used for the support decision and an os_minor used for snapshot selection. So
+# redhat9.7 and redhat9.8 resolve to rhel9 here; the raw --os input is kept
+# in the ``raw_os`` column; the decision uses the canonical major-only name.
+
+# (current_version, raw_os, canonical_os, upgrade_from, supported)
+# upgrade_from is what _get_precedent_major(..., 'stable') resolves to.
+# scalityos: the live upgrade FROM comes from the ADI manifest (that path is
+# skipped for scalityos in __init__); these rows assert the is_valid_upgrade
+# rule only.
+UPGRADE_MATRIX = [
+    ("8.5.12.0", "redhat8.10", "rhel8", "8.5.11", True),
+    ("8.5.12.0", "rocky8.10", "rocky8", "8.5.11", True),
+    ("8.5.13.0", "redhat8.10", "rhel8", "8.5.12", True),
+    ("8.5.13.0", "rocky8.10", "rocky8", "8.5.12", True),
+    ("9.5.2.0", "redhat8.10", "rhel8", "9.5.1", True),
+    ("9.5.2.0", "redhat9.7", "rhel9", "9.5.1", True),
+    ("9.5.2.0", "redhat9.8", "rhel9", "9.5.1", True),
+    ("9.5.2.0", "rocky8.10", "rocky8", "9.5.1", True),
+    ("9.5.2.0", "rocky9", "rocky9", "9.5.1", True),
+    ("9.5.3.0", "redhat8.10", "rhel8", "9.5.2", True),
+    ("9.5.3.0", "redhat9.7", "rhel9", "9.5.2", True),
+    ("9.5.3.0", "redhat9.8", "rhel9", "9.5.2", True),
+    ("9.5.3.0", "rocky8.10", "rocky8", "9.5.2", True),
+    ("9.5.3.0", "rocky9", "rocky9", "9.5.2", True),
+    ("10.0.0.0", "redhat9.7", "rhel9", "9", True),
+    ("10.0.0.0", "redhat9.8", "rhel9", "9", True),
+    ("10.0.0.0", "rocky9", "rocky9", "9", True),
+    ("10.0.0.0", "scalityos", "scalityos", "9", False),
+    ("10.1.0.0", "redhat9.7", "rhel9", "10.0", True),
+    ("10.1.0.0", "redhat9.8", "rhel9", "10.0", True),
+    ("10.1.0.0", "rocky9", "rocky9", "10.0", True),
+    ("10.1.0.0", "scalityos", "scalityos", "10.0", True),
+]
+
+# (current_version, raw_os, canonical_os, upgradeprev_from, supported)
+# upgradeprev_from is what _get_precedent_major(..., 'previous') resolves to
+# via TECH_TRAIN.
+# rhel9/rocky9 upgradeprev is refused for a RING 9 target (previous tech-train
+# is RING 8, no rhel9/rocky9 image) and allowed for RING >= 10 (previous
+# tech-train 9.5.2 is rhel9/rocky9-capable) — see RING-54645 (PR #7045).
+UPGRADEPREV_MATRIX = [
+    ("8.5.12.0", "redhat8.10", "rhel8", "7.4.10", False),
+    ("8.5.12.0", "rocky8.10", "rocky8", "7.4.10", False),
+    ("8.5.13.0", "redhat8.10", "rhel8", "7.4.10", False),
+    ("8.5.13.0", "rocky8.10", "rocky8", "7.4.10", False),
+    ("9.5.2.0", "redhat8.10", "rhel8", "8.5.12", True),
+    ("9.5.2.0", "redhat9.7", "rhel9", "8.5.12", False),
+    ("9.5.2.0", "redhat9.8", "rhel9", "8.5.12", False),
+    ("9.5.2.0", "rocky8.10", "rocky8", "8.5.12", True),
+    ("9.5.2.0", "rocky9", "rocky9", "8.5.12", False),
+    ("9.5.3.0", "redhat8.10", "rhel8", "8.5.12", True),
+    ("9.5.3.0", "redhat9.7", "rhel9", "8.5.12", False),
+    ("9.5.3.0", "redhat9.8", "rhel9", "8.5.12", False),
+    ("9.5.3.0", "rocky8.10", "rocky8", "8.5.12", True),
+    ("9.5.3.0", "rocky9", "rocky9", "8.5.12", False),
+    ("10.0.0.0", "redhat9.7", "rhel9", "9.5.2", True),
+    ("10.0.0.0", "redhat9.8", "rhel9", "9.5.2", True),
+    ("10.0.0.0", "rocky9", "rocky9", "9.5.2", True),
+    ("10.0.0.0", "scalityos", "scalityos", "9.5.2", False),
+    ("10.1.0.0", "redhat9.7", "rhel9", "9.5.2", True),
+    ("10.1.0.0", "redhat9.8", "rhel9", "9.5.2", True),
+    ("10.1.0.0", "rocky9", "rocky9", "9.5.2", True),
+    ("10.1.0.0", "scalityos", "scalityos", "9.5.2", False),
+]
+
+
+@pytest.mark.parametrize(
+    "current,raw_os,canonical,upgrade_from,supported", UPGRADE_MATRIX,
+    ids=[f"{c}-{o}" for c, o, _, _, _ in UPGRADE_MATRIX])
+def test_upgrade_matrix(current, raw_os, canonical, upgrade_from, supported):
+    assert _upgrade_supported(
+        canonical, current, upgrade_from, is_previous=False) is supported
+
+
+@pytest.mark.parametrize(
+    "current,raw_os,canonical,upgradeprev_from,supported", UPGRADEPREV_MATRIX,
+    ids=[f"{c}-{o}" for c, o, _, _, _ in UPGRADEPREV_MATRIX])
+def test_upgradeprev_matrix(current, raw_os, canonical, upgradeprev_from,
+                            supported):
+    assert _upgrade_supported(
+        canonical, current, upgradeprev_from, is_previous=True) is supported
 
 
 def _snap(osver, ring=RING, nodes=3, suffix=SUFFIX, family="redhat"):

--- a/arti-compute/test_arti_compute.py
+++ b/arti-compute/test_arti_compute.py
@@ -1,0 +1,92 @@
+"""Unit tests for arti_compute OS-minor-aware snapshot selection (RING-54644)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from arti_compute import ArtiCompute, _split_os_minor   # noqa: E402
+
+
+RING = "9.5.2.5"
+SUFFIX = "GA"
+
+
+def _snap(osver, ring=RING, nodes=3, suffix=SUFFIX, family="redhat"):
+    """Build a snapshot platform_name as tagged by installci."""
+    return f"RING-{ring}-{family}{osver}-{nodes}nodes[{suffix}]"
+
+
+def _select(snapshots, os_minor, os_major="9", family="redhat", suffix=SUFFIX):
+    return ArtiCompute._select_snapshot(
+        snapshots, RING, family, os_major, os_minor, suffix)
+
+
+class TestSplitOsMinor:
+    def test_with_minor(self):
+        assert _split_os_minor("rhel9.6") == ("rhel9", "9.6")
+
+    def test_without_minor(self):
+        assert _split_os_minor("rhel9") == ("rhel9", None)
+        assert _split_os_minor("rocky9") == ("rocky9", None)
+
+    def test_double_digit_major(self):
+        assert _split_os_minor("rhel10.2") == ("rhel10", "10.2")
+
+    def test_scalityos_unchanged(self):
+        assert _split_os_minor("scalityos-9.7") == ("scalityos-9.7", None)
+
+
+class TestSelectSnapshot:
+    def test_exact_minor(self):
+        snaps = [_snap("9.6"), _snap("9.7")]
+        assert _select(snaps, "9.6") == _snap("9.6")
+
+    def test_highest_below_target(self):
+        # target 9.8, only 9.6/9.7 exist -> highest <= target
+        snaps = [_snap("9.6"), _snap("9.7")]
+        assert _select(snaps, "9.8") == _snap("9.7")
+
+    def test_no_minor_below_target_returns_none(self):
+        # No-match case 1: candidates exist for this (ring, major, suffix) set
+        # but none is <= target (target 9.4, only 9.6/9.7). Returns None ->
+        # caller falls back to a fresh install-for-upgrade (as before).
+        snaps = [_snap("9.6"), _snap("9.7")]
+        assert _select(snaps, "9.4") is None
+
+    def test_no_candidates_returns_none(self):
+        # No-match case 2: no snapshot at all for this (ring, major, suffix)
+        # set (only another major present). Returns None -> fresh install.
+        snaps = [_snap("8.10")]
+        assert _select(snaps, "9.6", os_major="9") is None
+        assert _select(snaps, None, os_major="9") is None
+
+    def test_major_only_target_picks_highest(self):
+        snaps = [_snap("9.6"), _snap("9.7")]
+        assert _select(snaps, None) == _snap("9.7")
+
+    def test_bare_major_fallback(self):
+        # target 9.6: 9.8 too high, bare "9" (minor 0) is the fallback
+        snaps = [_snap("9"), _snap("9.8")]
+        assert _select(snaps, "9.6") == _snap("9")
+
+    def test_bare_major_only_available(self):
+        snaps = [_snap("9")]
+        assert _select(snaps, "9.7") == _snap("9")
+        assert _select(snaps, None) == _snap("9")
+
+    def test_other_major_ignored(self):
+        snaps = [_snap("8.10"), _snap("9.6")]
+        assert _select(snaps, "9.6") == _snap("9.6")
+        assert _select([_snap("8.10")], "9.6", os_major="9") is None
+
+    def test_suffix_mismatch_ignored(self):
+        snaps = [_snap("9.6", suffix="mytest")]
+        assert _select(snaps, "9.6", suffix="GA") is None
+        assert _select(snaps, "9.6", suffix="mytest") == _snap("9.6", suffix="mytest")
+
+    def test_rocky_family(self):
+        snaps = [_snap("9", family="rocky"), _snap("9.6", family="redhat")]
+        assert _select(snaps, None, family="rocky") == _snap("9", family="rocky")
+
+    def test_empty(self):
+        assert _select([], "9.6") is None

--- a/arti-compute/test_arti_compute.py
+++ b/arti-compute/test_arti_compute.py
@@ -19,10 +19,6 @@ import arti_compute as ac                                # noqa: E402
 from arti_compute import ArtiCompute, _split_os_minor    # noqa: E402
 
 
-RING = "9.5.2.5"
-SUFFIX = "GA"
-
-
 def _ac(os_name, ring_version):
     """Build a minimal ArtiCompute instance without running __init__."""
     obj = ArtiCompute.__new__(ArtiCompute)
@@ -127,16 +123,6 @@ def test_upgradeprev_matrix(current, raw_os, canonical, upgradeprev_from,
         canonical, current, upgradeprev_from, is_previous=True) is supported
 
 
-def _snap(osver, ring=RING, nodes=3, suffix=SUFFIX, family="redhat"):
-    """Build a snapshot platform_name as tagged by installci."""
-    return f"RING-{ring}-{family}{osver}-{nodes}nodes[{suffix}]"
-
-
-def _select(snapshots, os_minor, os_major="9", family="redhat", suffix=SUFFIX):
-    return ArtiCompute._select_snapshot(
-        snapshots, RING, family, os_major, os_minor, suffix)
-
-
 # OS tuple is built from _ring_major; assert each OS's membership against the
 # _ring_major resolved at import (testdata/VERSION via conftest.py) so this
 # stays correct whichever RING version the action is pinned to.
@@ -151,72 +137,102 @@ def test_os_tuple_gating(os_name, expected_present):
     assert (os_name in ac.OS) is expected_present
 
 
-class TestSplitOsMinor:
-    def test_with_minor(self):
-        assert _split_os_minor("rhel9.6") == ("rhel9", "9.6")
-
-    def test_without_minor(self):
-        assert _split_os_minor("rhel9") == ("rhel9", None)
-        assert _split_os_minor("rocky9") == ("rocky9", None)
-
-    def test_double_digit_major(self):
-        assert _split_os_minor("rhel10.2") == ("rhel10", "10.2")
-
-    def test_scalityos_unchanged(self):
-        assert _split_os_minor("scalityos-9.7") == ("scalityos-9.7", None)
+SPLIT_OS_MINOR_CASES = [
+    ("rhel9.6", ("rhel9", "9.6")),
+    ("rhel9", ("rhel9", None)),
+    ("rocky9", ("rocky9", None)),
+    ("rocky8.10", ("rocky8", "8.10")),
+    # double-digit major: the minor must not swallow the major's second digit
+    ("rhel10.2", ("rhel10", "10.2")),
+    ("scalityos-9.7", ("scalityos-9.7", None)),
+]
 
 
-class TestSelectSnapshot:
-    def test_exact_minor(self):
-        snaps = [_snap("9.6"), _snap("9.7")]
-        assert _select(snaps, "9.6") == _snap("9.6")
+@pytest.mark.parametrize("os_name,expected", SPLIT_OS_MINOR_CASES,
+                         ids=[c[0] for c in SPLIT_OS_MINOR_CASES])
+def test_split_os_minor(os_name, expected):
+    assert _split_os_minor(os_name) == expected
 
-    def test_highest_below_target(self):
-        # target 9.8, only 9.6/9.7 exist -> highest <= target
-        snaps = [_snap("9.6"), _snap("9.7")]
-        assert _select(snaps, "9.8") == _snap("9.7")
 
-    def test_no_minor_below_target_returns_none(self):
-        # No-match case 1: candidates exist for this (ring, major, suffix) set
-        # but none is <= target (target 9.4, only 9.6/9.7). Returns None ->
-        # caller falls back to a fresh install-for-upgrade (as before).
-        snaps = [_snap("9.6"), _snap("9.7")]
-        assert _select(snaps, "9.4") is None
+# Real platform_name snapshot tags (from live AWS). Bare-major tags (redhat9,
+# rocky9) count as minor 0; two non-GA redhat9.6 tags test suffix filtering.
+SNAPSHOTS = [
+    "RING-9.5.2.6-redhat8-3nodes[GA]",
+    "RING-9.5.2.6-redhat9-3nodes[GA]",
+    "RING-9.5.2.6-redhat9.6-3nodes[GA]",
+    "RING-9.5.2.6-redhat9.6-3nodes[9.5.2.6_pw1]",
+    "RING-9.5.2.6-redhat9.6-3nodes[redhat96-test]",
+    "RING-9.5.2.6-rocky8-3nodes[GA]",
+    "RING-9.5.2.6-rocky9-3nodes[GA]",
+    "RING-10.0.0.0-redhat9.6-3nodes[GA]",
+    "RING-10.0.0.0-redhat9.7-3nodes[GA]",
+    "RING-10.1.0.0-redhat9.7-3nodes[GA]",
+    "RING-10.1.0.0-redhat9.8-3nodes[GA]",
+]
 
-    def test_no_candidates_returns_none(self):
-        # No-match case 2: no snapshot at all for this (ring, major, suffix)
-        # set (only another major present). Returns None -> fresh install.
-        snaps = [_snap("8.10")]
-        assert _select(snaps, "9.6", os_major="9") is None
-        assert _select(snaps, None, os_major="9") is None
+# The trailing "9.9" is a middle segment: the anchored regex must read osver as
+# the bare major (minor 0), never 9.9.
+ANCHOR_SNAPSHOTS = [
+    "RING-9.5.2.6-redhat9-3nodes-extra-redhat9.9[GA]",
+    "RING-9.5.2.6-redhat9.5-3nodes[GA]",
+]
 
-    def test_major_only_target_picks_highest(self):
-        snaps = [_snap("9.6"), _snap("9.7")]
-        assert _select(snaps, None) == _snap("9.7")
+# Only another major is present, so a major-9 request has no candidate at all.
+OTHER_MAJOR_ONLY = ["RING-9.5.2.6-redhat8.10-3nodes[GA]"]
 
-    def test_bare_major_fallback(self):
-        # target 9.6: 9.8 too high, bare "9" (minor 0) is the fallback
-        snaps = [_snap("9"), _snap("9.8")]
-        assert _select(snaps, "9.6") == _snap("9")
+# Only a bare-major tag is present (minor 0).
+BARE_MAJOR_ONLY = ["RING-9.5.2.6-redhat9-3nodes[GA]"]
 
-    def test_bare_major_only_available(self):
-        snaps = [_snap("9")]
-        assert _select(snaps, "9.7") == _snap("9")
-        assert _select(snaps, None) == _snap("9")
+# (id, snapshots, ring_version, family, major, minor, suffix, expected)
+# minor is the full 'major.minor' or None; family is 'redhat', not 'rhel'.
+SELECT_SNAPSHOT_CASES = [
+    ("exact-minor", SNAPSHOTS, "10.0.0.0", "redhat", "9", "9.7", "GA",
+     "RING-10.0.0.0-redhat9.7-3nodes[GA]"),
+    # real CI anchor: 9.8 requested, highest available is 9.6
+    ("highest-below-target", SNAPSHOTS, "9.5.2.6", "redhat", "9", "9.8", "GA",
+     "RING-9.5.2.6-redhat9.6-3nodes[GA]"),
+    ("never-higher-minor", SNAPSHOTS, "10.1.0.0", "redhat", "9", "9.6", "GA",
+     None),
+    ("major-only-highest", SNAPSHOTS, "10.1.0.0", "redhat", "9", None, "GA",
+     "RING-10.1.0.0-redhat9.8-3nodes[GA]"),
+    ("bare-major-minor0-fallback", SNAPSHOTS, "9.5.2.6", "redhat", "9", "9.5",
+     "GA", "RING-9.5.2.6-redhat9-3nodes[GA]"),
+    ("bare-major-rocky", SNAPSHOTS, "9.5.2.6", "rocky", "9", "9.9", "GA",
+     "RING-9.5.2.6-rocky9-3nodes[GA]"),
+    ("other-major-isolated", SNAPSHOTS, "9.5.2.6", "redhat", "8", "8.10", "GA",
+     "RING-9.5.2.6-redhat8-3nodes[GA]"),
+    ("suffix-mismatch-ignored", SNAPSHOTS, "9.5.2.6", "redhat", "9", "9.6",
+     "GA", "RING-9.5.2.6-redhat9.6-3nodes[GA]"),
+    ("wrong-ring-version", SNAPSHOTS, "9.9.9.9", "redhat", "9", "9.9", "GA",
+     None),
+    ("family-mismatch", SNAPSHOTS, "9.5.2.6", "redhat", "9", None, "GA",
+     "RING-9.5.2.6-redhat9.6-3nodes[GA]"),
+    ("empty-list", [], "9.5.2.6", "redhat", "9", "9.6", "GA", None),
+    ("anchoring", ANCHOR_SNAPSHOTS, "9.5.2.6", "redhat", "9", "9.9", "GA",
+     "RING-9.5.2.6-redhat9.5-3nodes[GA]"),
+    # No candidate for the requested major at all -> None, both with and
+    # without a requested minor (caller falls back to a fresh install).
+    ("no-candidate-for-major", OTHER_MAJOR_ONLY, "9.5.2.6", "redhat", "9",
+     "9.6", "GA", None),
+    ("no-candidate-for-major-no-minor", OTHER_MAJOR_ONLY, "9.5.2.6", "redhat",
+     "9", None, "GA", None),
+    # Bare major is the only tag: eligible for a minor request and for a
+    # major-only request alike.
+    ("bare-major-only-with-minor", BARE_MAJOR_ONLY, "9.5.2.6", "redhat", "9",
+     "9.7", "GA", "RING-9.5.2.6-redhat9-3nodes[GA]"),
+    ("bare-major-only-no-minor", BARE_MAJOR_ONLY, "9.5.2.6", "redhat", "9",
+     None, "GA", "RING-9.5.2.6-redhat9-3nodes[GA]"),
+    # Requested suffix matches nothing -> None.
+    ("suffix-matches-nothing", SNAPSHOTS, "9.5.2.6", "redhat", "9", "9.6",
+     "no-such-suffix", None),
+]
 
-    def test_other_major_ignored(self):
-        snaps = [_snap("8.10"), _snap("9.6")]
-        assert _select(snaps, "9.6") == _snap("9.6")
-        assert _select([_snap("8.10")], "9.6", os_major="9") is None
 
-    def test_suffix_mismatch_ignored(self):
-        snaps = [_snap("9.6", suffix="mytest")]
-        assert _select(snaps, "9.6", suffix="GA") is None
-        assert _select(snaps, "9.6", suffix="mytest") == _snap("9.6", suffix="mytest")
-
-    def test_rocky_family(self):
-        snaps = [_snap("9", family="rocky"), _snap("9.6", family="redhat")]
-        assert _select(snaps, None, family="rocky") == _snap("9", family="rocky")
-
-    def test_empty(self):
-        assert _select([], "9.6") is None
+@pytest.mark.parametrize(
+    "snapshots,ring_version,family,major,minor,suffix,expected",
+    [c[1:] for c in SELECT_SNAPSHOT_CASES],
+    ids=[c[0] for c in SELECT_SNAPSHOT_CASES])
+def test_select_snapshot(snapshots, ring_version, family, major, minor, suffix,
+                         expected):
+    assert ArtiCompute._select_snapshot(
+        snapshots, ring_version, family, major, minor, suffix) == expected


### PR DESCRIPTION
Targets `improvement/RING-54589-arti-compute` (#166), not `main`.

## Problem

#166 snapshots `arti_compute.py` from RING at **`851a2e5`, 2026-07-15**. Four RING
changes landed after that point, and the script arrived with no unit tests. This PR
closes the gap and brings the tests over, so the hosted copy is not born stale.

The divergence point was found by hashing #166's `arti_compute.py` against every
historical version of the file in RING (three paths: `old-installer-tests/`,
`new-installer-tests/`, `installer-tests/`). No exact match exists; the closest is
`851a2e5` at an 89-line distance, and that delta is **entirely** your intentional
action adaptation:

- `_peek_argv_version_file()` / `_resolve_version_file()` — locate `VERSION` outside a
  RING checkout (argv → `RING_VERSION_FILE`/`VERSION_FILE` → `GITHUB_WORKSPACE` → cwd
  walk → legacy walk)
- `--version-file` / `--output-file` CLI arguments
- `as_bash_vars(..., outfile=...)` routing

Runners-up, for the record: `18033f8` (RING-54551) at 93 lines, `2a6a6b9` (RING-54105)
at 101, `db13b3e` (RING-53739) at 103.

## What this PR adds

### Missing script changes

| Commit here | RING commit | RING PR | Ticket |
|---|---|---|---|
| `dcd813f` | `9cc484c` | [#7045](https://github.com/scality/ring/pull/7045) MERGED | RING-54645 — allow rhel9/rocky9 `upgradeprev` for RING 10+ |
| `b3772c2` | `2843145`, `e5fa6db` | [#7076](https://github.com/scality/ring/pull/7076), [#7077](https://github.com/scality/ring/pull/7077) MERGED | RING-54662 — `TECH_TRAIN['previous-9.5.4'] = '8.5.12'` |
| `3f57b46` | `86c3799` | [#7050](https://github.com/scality/ring/pull/7050) MERGED | RING-54644 — OS-minor-aware snapshot selection |

RING-54644 adds `_split_os_minor()`, `ArtiCompute._select_snapshot()`, `self.os_minor`,
threads `os_minor=` through the three `_find_snapshot()` call sites, drops the
`os_version` AWS filter (snapshots are tagged with either a bare major or a
major.minor), and stops `_fix_os_name()` from discarding the OS minor. It was applied
as a patch — all 10 hunks clean, pure line offset — then hand-checked, because it
touches `get_options()` right where #166 added `--version-file`/`--output-file`.

After these three commits `arti_compute.py` is content-equivalent to the merged
`development/8.5` copy plus your adaptation. Verified by normalised diff.

### Tests

`arti-compute/test_arti_compute.py`, **72 tests**, pure `pytest` — no network, AWS, or
artifact lookups. Instances are built with `__new__` so `__init__` never runs, and
`_select_snapshot` is a pure classmethod called directly.

| Commit here | RING commit | RING PR | Content |
|---|---|---|---|
| `4304990` | `82b30c6`, `9b4cd93` | [#7050](https://github.com/scality/ring/pull/7050) MERGED | RING-54644 snapshot-selection tests, class-based |
| `e70774e` | `00fe70c` | [#7067](https://github.com/scality/ring/pull/7067) OPEN | upgrade/upgradeprev matrix, 22 + 22 rows |
| `ace19da` | `3e33d6e` | [#7067](https://github.com/scality/ring/pull/7067) OPEN | OS-tuple gating by `_ring_major` |
| `8fbcf10` | `ca9a977` | [#7067](https://github.com/scality/ring/pull/7067) OPEN | table-driven `_split_os_minor` + `_select_snapshot` |

**Note on the two test suites.** #7050 merged its own `test_arti_compute.py` at the same
path #7067 uses, so upstream #7067 now needs a rebase. Neither suite is a subset of the
other, so this PR unions them rather than picking one — `8fbcf10` converts to #7067's
table-driven form while folding in every case only #7050 had:

| Only in #7050 → kept | Only in #7067 → kept |
|---|---|
| `rhel10.2` double-digit-major split | regex `anchoring` (trailing `9.9` as a middle segment) |
| no-candidate-for-major (with and without a minor) | `wrong-ring-version` |
| bare-major-only (with and without a minor) | |
| suffix-matches-nothing | |

Coverage: 44 matrix rows, 5 OS-gating, 6 `_split_os_minor`, 17 `_select_snapshot`.

The 44 matrix rows are what confirm the RING-54645 port: the RING-10 rhel9/rocky9
`upgradeprev` rows assert `True` and pass.

`arti_compute.py` resolves the VERSION file at **import** time (module-level
`_ring_major`), which fails outside a RING checkout — so `conftest.py` points
`RING_VERSION_FILE` at `testdata/VERSION`. With `VERSION=10.1.0.0`, `_ring_major` is 10
and `OS == ('rhel9', 'rocky9', 'scalityos')`. The gating test asserts membership
*against* `ac._ring_major`, so it stays correct whatever the pinned VERSION says.

### CI and lint

`08ddb16` adds a `pytest` job and a `flake8` job to `test-arti-compute.yaml`, an
`arti-compute/.flake8` (`max-line-length = 120`), and `requirements-dev.txt` — so
`pytest`/`flake8` are not runtime dependencies of the action.

`203a4d6` clears the 30 flake8 violations inherited from the RING copy. Cosmetic only:
F541, E202, E203, E222, E261, E302, E305, E306, E501, E712. 120 was chosen over 100 to
keep churn in the inherited file low (30 fixes rather than 54) and future RING syncs
easy.

### Bug found while linting

`800d1d3` — the four S3 lookup regexes are f-strings, so `{0,3}` was parsed as an
f-string replacement field and rendered as the tuple `(0, 3)`:

```
github:scality:[fF]ederation:promoted-9.5([.](\d+[.]?)(0, 3))?/$
```

The group is optional, so the bare version still matched and this went unnoticed — but
no patch-level version did:

| candidate | before | after |
|---|---|---|
| `promoted-9.5/` | matches | matches |
| `promoted-9.5.2/` | **no match** | matches |
| `promoted-9.5.2.6/` | **no match** | matches |

Escaped as `{{0,3}}`. This is the only behaviour change in the PR, deliberately isolated
in its own commit so it can be reverted on its own if you would rather it went in
separately. **It is pre-existing in RING's `arti_compute.py` and needs the same fix
there** — tracked as a follow-up below.

## Full RING provenance

Every commit that touched `arti_compute.py` after the #166 base, including per-branch
cherry-picks not ported here (same change, different RING version line):

| RING commit | Date | PR | State | Note |
|---|---|---|---|---|
| `851a2e5` / `d0b7954` | 2026-07-15 | [#6999](https://github.com/scality/ring/pull/6999) | MERGED | RING-54059 — **the #166 base** |
| `9cc484c` | 2026-07-21 | [#7045](https://github.com/scality/ring/pull/7045) | MERGED | RING-54645 — ported |
| `85a3a35`, `bdf3a8e` | 2026-07-21 | — | — | RING-54645, 9.5.2 branch variants |
| `8014cd6` | 2026-07-22 | — | — | bert-e queue merge of RING-54645 into `q/9.5.2.6` |
| `86c3799` | 2026-07-21 | [#7050](https://github.com/scality/ring/pull/7050) | MERGED | RING-54644 — ported |
| `a1be001` | 2026-07-21 | [#7052](https://github.com/scality/ring/pull/7052) | MERGED | RING-54644 cherry-pick, `hotfix/10.0.0` |
| `a499dff` | 2026-07-21 | [#7103](https://github.com/scality/ring/pull/7103) | MERGED | RING-54644 cherry-pick, `hotfix/9.5.3` |
| `82b30c6`, `9b4cd93` | 2026-07-21 | [#7050](https://github.com/scality/ring/pull/7050) | MERGED | RING-54644 tests — ported |
| `a350140`, `03442bc`, `41ecc72` | 2026-07-21 | #7052, #7103 | MERGED | same test commits on the cherry-pick branches |
| `2843145` | 2026-07-23 | [#7076](https://github.com/scality/ring/pull/7076) | MERGED | RING-54662 — ported |
| `e5fa6db` | 2026-07-23 | [#7077](https://github.com/scality/ring/pull/7077) | MERGED | RING-54662 integration to `development/10` |
| `00fe70c` | 2026-07-22 | [#7067](https://github.com/scality/ring/pull/7067) | OPEN | RING-54657 tests — ported |
| `ca9a977` | 2026-07-27 | [#7067](https://github.com/scality/ring/pull/7067) | OPEN | RING-54657 tests — ported |
| `3e33d6e` | 2026-07-27 | [#7067](https://github.com/scality/ring/pull/7067) | OPEN | RING-54657 tests — ported |

All three `development` branches (8.5, 9.5, 10) carry a byte-identical
`arti_compute.py` via shared-file sync, so the divergence is the same for each.

### Hotfix branches checked

`hotfix/10.0.0` and `hotfix/9.5.3` were audited separately for anything the
`development` line does not carry. Nothing was missed:

- The only `arti_compute.py` commits on those branches that are not ancestors of any
  `development` branch are the RING-54644 / RING-54645 cherry-picks (`a1be001`,
  `a499dff`, `85a3a355`). All are **patch-id identical** to the `development` commits
  ported here (`d8cc0cac` for RING-54644, `f8ee4130` for RING-54645).
- `test_arti_compute.py` is the **same blob** (`27a6744`) on `hotfix/10.0.0`,
  `hotfix/9.5.3` and `development/8.5` — exactly the file ported in `4304990`.
- `hotfix/9.5.3` differs from `development/8.5` by one line only: it lacks
  `previous-9.5.4`, correct for a 9.5.3 hotfix.
- `hotfix/10.0.0` is behind on unrelated, release-appropriate points (the `OS` tuple
  literal, the RING 11+ scalityos `upgradeprev` refinement, `previous-9.5.4`). No
  hotfix-only logic exists that this PR lacks.

`hotfix/9.5.2` also carries RING-54645 as `bdf3a8e` — same added/removed lines, a
different patch-id only because the surrounding context on that older file differs. It
has no `test_arti_compute.py`.

## Ownership

`03c3eb8` makes `@scality/supsetup` the code owner of `arti-compute/` and its test
workflow, matching RING where `arti_compute` is theirs. Note this went in the **root**
`CODEOWNERS`, not a new `.github/CODEOWNERS` — the latter takes precedence over the root
file and would have silently dropped the repo-wide `* @scality/platform-eng` default.

## Testing

```bash
cd arti-compute
pip install -r requirements-dev.txt
python -m pytest test_arti_compute.py -v    # 72 passed
python -m flake8 .                          # clean
python arti_compute.py --check-tech-train 10.1.0.0 --version-file testdata/VERSION
```

Both new CI jobs run on any change under `arti-compute/`.

## Follow-ups

- #7067 needs a rebase upstream now that #7050 landed a file at the same path; the union
  in `8fbcf10` is what that rebase should converge on.
- The `{{0,3}}` fix belongs in RING's copy too.

Epic: RING-53369
